### PR TITLE
Нумератор по линии: Изменена логика поиска нумерумых помещений

### DIFF
--- a/АР.tab/Квартирография.panel/Нумераторы.pulldown/Нумератор по линии.pushbutton/script.py
+++ b/АР.tab/Квартирография.panel/Нумераторы.pulldown/Нумератор по линии.pushbutton/script.py
@@ -30,7 +30,7 @@ log_debug = False
 log_point_debug = False
 log_elapsed_time_debug = False
 
-text_debug = True
+text_debug = False
 circle_debug = False
 
 eps = 1.0e-9


### PR DESCRIPTION
Обновлен скрипт для нумерации помещений по линии.
Изменена логика поиска пересечений линии и помещений.

В исходной версии производился поиск пересечений с BoundingBox помещений, из-за этого в случае с наклонными в плане помещениями линия ошибочно попадала в другие помещения.
![Screenshot_16](https://github.com/user-attachments/assets/987c545f-9982-49bc-b706-da142bb50e0f)

Теперь поиск пересечений производится через метод GetRoomAtPoint класса Document.